### PR TITLE
feat(winui3): dispatcher watchdog log sink + CP WATCHDOG pull (#214)

### DIFF
--- a/.dispatch/team-g-winui3-dispatcher-watchdog-brief.md
+++ b/.dispatch/team-g-winui3-dispatcher-watchdog-brief.md
@@ -1,0 +1,76 @@
+cwd: C:/Users/yuuji/ghostty-win
+
+# Team G — WinUI3 apprt dispatcher watchdog
+
+## 目的
+Issue **YuujiKamura/ghostty#214** (WinUI3 runtime: thinking-state timer freeze / CP pipe input stalls under 4+ concurrent Claude sessions) の investigation #2 を実装:
+
+> 2. Add a watchdog in the WinUI3 apprt that logs when the main thread dispatcher goes >3s without pumping. Write to CP pipe so external monitors (deckpilot) can detect
+
+次回 hang が発生した際に「どの session の dispatcher がどの瞬間に止まったか」を外部から観測できるようにする。hang 自体の fix ではない、observability 追加のみ。
+
+## 前提 (要読み込み)
+- `PLAN.md` (プロジェクト規約、セッション開始時に必読と CLAUDE.md に明記)
+- `AGENTS.md` (存在すれば)
+- `src/apprt/winui3/` または類似パス — WinUI3 apprt の zig 実装箇所
+- CP pipe 書き込み先: 既存の CP pipe server 実装を流用 (grep で `CP` / `named-pipe` / `pipe-server` 当たりを探せ、memory `win32-cp-pipe-architecture` 参照)
+- 既存の hang memory: `~/.claude/projects/C--Users-yuuji/memory/project_ghostty_winui3_hang_28900.md` — 類似症状、併記して related-to-issue-139 と記録
+
+## 要件
+1. WinUI3 apprt の **main dispatcher thread が pulse を出す仕組み** を追加:
+   - 毎 N 秒 (N=1 を既定値、将来調整可能) に tick をログ先へ書き出す
+   - ログ先候補: (a) 既存 CP pipe の新規メッセージ種 `DISPATCHER_PULSE`、(b) `%LOCALAPPDATA%/ghostty/dispatcher-watchdog-<pid>.log` に追記、(c) 両方。CP pipe 側に寄せるのが deckpilot との親和性で有利、brief としては CP pipe 経由を優先、log file は fallback
+   - pulse payload: `timestamp`, `session_pid`, 可能なら `last_message_processed_id` や `queue_length`
+2. **別 thread (watchdog)** が pulse を監視、前 pulse から **3 秒**超過したら alert を書き出す:
+   - alert 先: (a) `stderr`、(b) CP pipe の `DISPATCHER_STALL` メッセージ、(c) log file
+   - alert payload: `detected_at`, `session_pid`, `last_pulse_at`, `elapsed_ms`
+3. 既存の ghostty WinUI3 起動/シャットダウンに統合:
+   - `init` 時に watchdog thread spawn
+   - `deinit` 時に watchdog kill + log close
+   - app crash 時に log flush
+4. **deckpilot 側の consume は実装しない** (別 team scope)、ghostty 側が吐く契約だけ固める
+5. 計測コスト: pulse thread の CPU 負荷 < 0.1% at idle、memory overhead < 1MB
+6. `./build-winui3.sh` が通ること (必ずラッパー経由、直接 zig build で WinUI3 を触るな — CLAUDE.md 明記)
+7. 単一セッション起動で動作確認、log に tick が 1 秒ごとに載り、`Sleep(5000)` 等で main thread を意図的にブロックすると DISPATCHER_STALL alert が立つことを目視確認
+8. 4 session 同時起動での hang 再現テストはこの team の scope 外 (issue 再現実験は人手判断)。あくまで **watchdog 単体が機能することを検証**
+
+## スコープ (厳守)
+触っていい:
+- `src/apprt/winui3/` 配下 (watchdog module 追加、init/deinit 接続)
+- `src/terminal/` は read-only で参照可 (既存 dispatcher パターン理解用)
+- `src/cp-pipe/` or 相当 (CP pipe の message type enum 拡張)
+- `build.zig` (新規ファイル登録が必要なら)
+- `docs/` (設計メモ追加、任意)
+- `.dispatch/team-g-winui3-dispatcher-watchdog-report.md` (新規 report)
+
+触ってはいけない:
+- `src/apprt/` の他 runtime (embedded, gtk, macos 等) — WinUI3 のみ
+- `src/terminal/` の既存コード **改変** (参照のみ)
+- `zig-out*/` (ビルド成果物)
+- `vendor/`, `third_party/`, 他 submodule 内部
+- `PLAN.md`, `AGENTS.md`, `CLAUDE.md` (読むだけ、改変禁止)
+- `scripts/`, `.github/`
+- upstream (`origin` = ghostty-org/ghostty) には **絶対 push するな** / PR も issue comment も禁止 (CLAUDE.md 明記)
+- remote `fork` (= YuujiKamura/ghostty) への push は自由
+
+## 禁止
+- `git add .` / `-A` / `-u` 全部禁止。**`git add <specific-file>` + `git commit -o <path>...`** のみ (memory `feedback_parallel_team_index_contamination.md`)
+- `--no-verify`, force push, upstream push
+- WinUI3 build を `zig build` 直接実行 (必ず `./build-winui3.sh`)
+- テスト hang 再現で 4 session 同時起動する実験
+- watchdog 以外の「ついでに直したい」修正 (issue #214 の他 investigation は別 team)
+
+## 検証
+- `./build-winui3.sh` green
+- 単一 WinUI3 ghostty 起動 → log に pulse tick が出る
+- 意図的に main thread を `Sleep(5000)` で止める dev 用 flag or test fixture を使って DISPATCHER_STALL が立つことを確認
+- 確認 log は `.dispatch/team-g-winui3-dispatcher-watchdog-report.md` に貼り付け
+
+## 完了条件
+- watchdog module 実装 (zig)
+- CP pipe / log 出力経路 (最低どちらか、両方が望ましい)
+- 単体動作確認 (pulse tick + stall alert)
+- `./build-winui3.sh` 成功
+- **fork (YuujiKamura/ghostty) の main branch に独立 commit + push**
+- `.dispatch/team-g-winui3-dispatcher-watchdog-report.md` に: 何を追加したか、どのファイルを触ったか、検証 log、既知の未解決点
+- issue #214 に **コメントを追加しない** (main-thread が後で PR 紐付けて処理、session が commit だけする)

--- a/.dispatch/team-g-winui3-dispatcher-watchdog-report.md
+++ b/.dispatch/team-g-winui3-dispatcher-watchdog-report.md
@@ -1,0 +1,106 @@
+# Team G — WinUI3 dispatcher watchdog — Report
+
+Issue: **YuujiKamura/ghostty#214** (WinUI3 runtime: thinking-state timer freeze / CP pipe input stalls under 4+ concurrent Claude sessions) — investigation #2 (observability: log when the main-thread dispatcher goes >3s without pumping, and expose it to external monitors).
+
+Related: commit `54479af8c` ("feat(winui3): Tier 1 UI-thread heartbeat watchdog (#212)") already wired an in-process heartbeat + stall latch; this team extends that scaffolding with a per-session log sink and a CP-pipe pull command so deckpilot can correlate which session's dispatcher is stuck.
+
+## Scope delivered
+
+1. **Log sink** — `%LOCALAPPDATA%\ghostty\dispatcher-watchdog-<pid>.log`, one ASCII line per event, `FlushFileBuffers` after each write.
+   - `PULSE t_ms=<unix_ms> pid=<u32> hb_age_ms=<u64> stalled=<0|1>` at 1 Hz from the UI thread.
+   - `STALL t_ms=<unix_ms> pid=<u32> elapsed_ms=<u64> last_pulse_t_ms=<unix_ms>` from the background watchdog thread when the 100ms heartbeat is stale ≥ 3s.
+   - `# session_start` / `# session_end` comment markers bracket the session for easy offline parsing.
+2. **CP-pipe pull command** — `WATCHDOG` returns
+   `OK|WATCHDOG|pid=<u32>|t_ms=<unix_ms>|last_pulse_t_ms=<unix_ms>|hb_age_ms=<u64>|stalled=<0|1>|last_stall_ms=<u64>|threshold_ms=3000`.
+   The existing `CAPABILITIES` string now advertises `WATCHDOG` in the `reads=` list so polling clients (deckpilot) can feature-detect.
+   Push was not re-added — `zig-control-plane` dropped its event-thread API (see `54479af8c` commit body); deckpilot must poll.
+3. **Dev fixture** — `GHOSTTY_WINUI3_WATCHDOG_TEST_STALL=1` arms a one-shot 5s-after-init UI-thread `Sleep(5000)` so the stall path can be exercised without real load. Never armed in production runs.
+
+The pre-existing Tier 1 heartbeat (100ms `WM_TIMER` + background poller + `ui_stall` log line) is unchanged apart from now also feeding `writeStall` into the log sink.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/apprt/winui3/watchdog.zig` | **New.** `DispatcherWatchdog` — mutex-guarded per-pid log file, `writePulse` / `writeStall` / `deinit` API. |
+| `src/apprt/winui3/App.zig` | Import `watchdog.zig`; add `DISPATCHER_PULSE_TIMER_ID` (1Hz) + `WATCHDOG_TEST_TRIGGER_TIMER_ID` (one-shot dev fixture); open/close `watchdog_log`; feed `writeStall` from `watchdogLoop`; add `controlPlaneCaptureWatchdog`; wire the fn into `ControlPlaneNative.create(...)` call; kill the new timers in `terminate`. |
+| `src/apprt/winui3/control_plane.zig` | Add `CaptureWatchdogFn` type + `capture_watchdog_fn` field; extend `create(...)` signature; intercept `WATCHDOG` command in `pipeHandler` before delegating to the library; add `WATCHDOG` to the `CAPABILITIES` reads list. |
+| `.dispatch/team-g-winui3-dispatcher-watchdog-report.md` | **New.** This report. |
+| `.dispatch/watchdog_probe.ps1` | **New.** PowerShell smoke probe used during verification (connects to the named pipe, issues `CAPABILITIES` + `WATCHDOG`). |
+
+No existing runtime logic was modified. Tier 1 heartbeat semantics (threshold = 3s, 100ms stamp cadence, per-stall debouncing) are preserved.
+
+## Verification
+
+Build:
+```
+$ ./build-winui3.sh
+[build-winui3] Finished promoting to zig-out-winui3.
+```
+(No errors, no warnings produced by the watchdog changes.)
+
+### A. Log sink (test-stall fixture)
+
+Command:
+```
+GHOSTTY_WINUI3_WATCHDOG_TEST_STALL=1 ./zig-out-winui3/bin/ghostty.exe
+```
+
+Actual log (`%LOCALAPPDATA%\ghostty\dispatcher-watchdog-47652.log`, truncated to the stall window):
+```
+# session_start pid=47652 t_ms=1776692584159
+PULSE t_ms=1776692585163 pid=47652 hb_age_ms=20 stalled=0
+PULSE t_ms=1776692586163 pid=47652 hb_age_ms=32 stalled=0
+PULSE t_ms=1776692587161 pid=47652 hb_age_ms=48 stalled=0
+PULSE t_ms=1776692588182 pid=47652 hb_age_ms=79 stalled=0
+STALL t_ms=1776692592167 pid=47652 elapsed_ms=3085 last_pulse_t_ms=1776692588182
+PULSE t_ms=1776692594168 pid=47652 hb_age_ms=5086 stalled=1
+PULSE t_ms=1776692594175 pid=47652 hb_age_ms=3 stalled=0
+PULSE t_ms=1776692595182 pid=47652 hb_age_ms=81 stalled=0
+...
+```
+
+Observations:
+- Idle-state `hb_age_ms` ≤ ~110ms (consistent with the 100ms `HEARTBEAT_TIMER_ID` cadence plus pulse-timer scheduling jitter).
+- `STALL` line arrives at `elapsed_ms=3085` — fires the first 1s-tick past the 3000ms threshold, as designed.
+- First PULSE after the stall shows `hb_age_ms=5086, stalled=1` (the 5s `Sleep` drained the heartbeat stamp); the watchdog thread had already latched `stalled=1` so the pulse correctly echoes it.
+- Subsequent PULSEs show `stalled=0` — the UI-thread heartbeat timer is re-stamping, so the latch releases naturally.
+
+### B. CP-pipe pull (normal load, no fixture)
+
+Command:
+```
+GHOSTTY_CONTROL_PLANE=1 GHOSTTY_SESSION_NAME=teamg-smoke ./zig-out-winui3/bin/ghostty.exe
+powershell -File .dispatch/watchdog_probe.ps1
+```
+
+Actual responses:
+```
+pipe=ghostty-winui3-teamg-smoke-15600
+[CAPABILITIES] OK|teamg-smoke|CAPABILITIES|transport=polling|reads=STATE,CAPTURE_PANE,TAIL,HISTORY,WAIT_FOR,PANE_PID,CURSOR_POS,PANE_TITLE,LIST_TABS,WATCHDOG|writes=INPUT,RAW_INPUT,PASTE,SEND_KEYS,ACK_POLL|control=NEW_TAB,CLOSE_TAB,SWITCH_TAB,FOCUS
+[WATCHDOG] OK|WATCHDOG|pid=15600|t_ms=1776692678130|last_pulse_t_ms=1776692677316|hb_age_ms=17|stalled=0|last_stall_ms=0|threshold_ms=3000
+```
+
+- `CAPABILITIES` advertises `WATCHDOG` in the `reads=` list — deckpilot can feature-detect without sniffer tables.
+- `WATCHDOG` payload matches the documented shape; `hb_age_ms=17` under idle load; `last_pulse_t_ms` is < 1s old, confirming the 1 Hz timer is live.
+- Session log for the same run (`dispatcher-watchdog-15600.log`, 50 PULSE entries, ~48s of uptime) shows steady-state `hb_age_ms` in the 12–113 ms range — no stall on an idle session.
+
+### C. Cost budget
+
+- Pulse write: `bufPrint` into 512-byte stack buffer + one `WriteFile` + one `FlushFileBuffers` per second. Negligible CPU at idle.
+- Watchdog thread: one `sleep(1s)` per iteration; atomic-load + comparison. Memory overhead: one `DispatcherWatchdog` heap allocation (~56 bytes + path string) plus the open `HANDLE`.
+- Log growth: ~60 bytes per PULSE entry → ~5 MB/day at steady state. Single-file; no rotation (deliberately — deckpilot is expected to tail and truncate out-of-band).
+
+## Known gaps / follow-ups
+
+1. **No log rotation.** Long-lived sessions grow the log monotonically. Acceptable for a ~1-day diagnostic window; a future team may want `log.<pid>.<rotated>.gz` hand-off on a size threshold.
+2. **CP push not restored.** The brief's primary option (DISPATCHER_PULSE / DISPATCHER_STALL CP messages) was delivered as a pull command (`WATCHDOG`) instead, because `zig-control-plane` removed its push/event-thread API in a previous refactor (see `54479af8c` commit body: "No CP EVENT push (API was removed)"). Re-adding push is out of scope for issue #214's observability increment — a polling consumer can achieve the same signal at the cost of a 1s-ish detection lag.
+3. **The dev fixture blocks the UI thread with `std.Thread.sleep`.** This is intentional for verification but will also block WM_PAINT and XAML input during the 5s window; users who arm the env var by mistake will see the window appear frozen. Consider gating on `builtin.mode == .Debug` in a follow-up.
+4. **Last-message-processed-id / queue-length were not added to PULSE payload.** The brief listed these as "可能なら"; the current XAML Islands apprt does not expose a stable per-dispatcher message counter, and synthesising one would require threading through `nonclient_island_window.wndproc` plus `DispatcherQueue.TryEnqueue` call-sites. Deferred as a separate increment if the single-session signal proves insufficient for distinguishing hang modes.
+5. **4-session concurrent hang reproduction was not attempted** (explicitly out-of-scope per brief §8). The watchdog contract alone is proven by the fixture.
+
+## Commit / push
+
+- Branch: `feat/ui-hang-resilience-integration` (active working branch — not `main`). Per CLAUDE.md, only the `fork` remote (`YuujiKamura/ghostty`) is pushed; `origin` (ghostty-org/ghostty) remains untouched.
+- `git add` used on specific files only (`src/apprt/winui3/watchdog.zig`, `src/apprt/winui3/App.zig`, `src/apprt/winui3/control_plane.zig`, `.dispatch/team-g-winui3-dispatcher-watchdog-report.md`, `.dispatch/watchdog_probe.ps1`). No `git add .` / `-A` / `-u`.
+- Issue #214 was **not** commented on, per brief — main-thread handles PR threading.

--- a/.dispatch/watchdog_probe.ps1
+++ b/.dispatch/watchdog_probe.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$SessionGlob = 'ghostty-winui3-teamg-smoke*'
+)
+$ErrorActionPreference = 'Stop'
+$pipeRoot = [System.IO.Path]::Combine([System.IO.Path]::DirectorySeparatorChar + [System.IO.Path]::DirectorySeparatorChar + '.', 'pipe')
+$pipes = Get-ChildItem -LiteralPath '\\.\pipe\' | Where-Object { $_.Name -like $SessionGlob }
+if (-not $pipes) {
+    Write-Host 'NO_PIPE'
+    exit 1
+}
+$pipeName = ($pipes | Select-Object -First 1).Name
+Write-Host "pipe=$pipeName"
+foreach ($cmd in @('CAPABILITIES','WATCHDOG')) {
+    $client = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipeName, [System.IO.Pipes.PipeDirection]::InOut)
+    $client.Connect(2000)
+    $writer = New-Object System.IO.StreamWriter($client)
+    $writer.AutoFlush = $true
+    $reader = New-Object System.IO.StreamReader($client)
+    $writer.WriteLine($cmd)
+    $resp = $reader.ReadLine()
+    Write-Host "[$cmd] $resp"
+    $client.Dispose()
+}

--- a/src/apprt/winui3/App.zig
+++ b/src/apprt/winui3/App.zig
@@ -40,6 +40,8 @@ const surface_binding = @import("surface_binding.zig");
 const event_handlers = @import("event_handlers.zig");
 const control_plane_mod = @import("control_plane.zig");
 const ControlPlaneNative = control_plane_mod.ControlPlane;
+const watchdog_mod = @import("watchdog.zig");
+const DispatcherWatchdog = watchdog_mod.DispatcherWatchdog;
 
 const nonclient_island_window = @import("nonclient_island_window.zig");
 const NonClientIslandWindow = nonclient_island_window.NonClientIslandWindow;
@@ -88,6 +90,16 @@ const CONTEXT_MENU_CLOSE_WINDOW: usize = 1004;
 const HEARTBEAT_TIMER_ID: usize = 1000;
 const HEARTBEAT_INTERVAL_MS: u32 = 100;
 const UI_STALL_THRESHOLD_NS: i128 = 3 * std.time.ns_per_s;
+/// 1 Hz dispatcher pulse timer (Team G, issue #214). Emits one PULSE entry
+/// per second to the dispatcher-watchdog-<pid>.log sink for external monitors.
+const DISPATCHER_PULSE_TIMER_ID: usize = 1005;
+const DISPATCHER_PULSE_INTERVAL_MS: u32 = 1000;
+/// Dev fixture: if `GHOSTTY_WINUI3_WATCHDOG_TEST_STALL` is set, the UI thread
+/// blocks for this many milliseconds ~5s after init so the log sink can be
+/// verified. Production builds never read this env var at runtime except once
+/// during initXaml.
+const WATCHDOG_TEST_STALL_MS: u32 = 5_000;
+const WATCHDOG_TEST_TRIGGER_TIMER_ID: usize = 1006;
 const APPMODEL_ERROR_NO_PACKAGE: i32 = 15700;
 const XamlClass = struct {
     const Application = "Microsoft.UI.Xaml.Application";
@@ -276,6 +288,16 @@ last_ui_stall_ms: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 ui_stalled_reported: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 watchdog_stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 watchdog_thread: ?std.Thread = null,
+
+/// Dispatcher watchdog log sink (Team G, issue #214). Writes one PULSE entry
+/// per second from the UI thread and one STALL entry from the background
+/// watchdog thread whenever the heartbeat is stale for >= 3s. Owned by the
+/// App; deinit'd in terminate(). `null` if the log file could not be opened.
+watchdog_log: ?*DispatcherWatchdog = null,
+/// Unix-ms timestamp of the last PULSE entry written, stamped from the UI
+/// thread. Read by the watchdog background thread so STALL entries can cite
+/// the last known-good pulse time.
+last_pulse_t_ms: std.atomic.Value(i64) = std.atomic.Value(i64).init(0),
 
 
     /// Get a surface by index. Thread-safe (acquires surfaces_mutex).
@@ -538,6 +560,7 @@ fn initXaml(self: *App) !void {
                 controlPlaneCaptureTail,
                 controlPlaneCaptureHistory,
                 controlPlaneCaptureTabList,
+                controlPlaneCaptureWatchdog,
             ) catch |err| blk: {
                 log.err("control_plane: create FAILED err={s}", .{@errorName(err)});
                 break :blk null;
@@ -578,10 +601,34 @@ fn initXaml(self: *App) !void {
     // updates, then spawn a background poller that flags stalls.
     self.last_ui_heartbeat_ns.store(std.time.nanoTimestamp(), .release);
     _ = os.SetTimer(self.hwnd.?, HEARTBEAT_TIMER_ID, HEARTBEAT_INTERVAL_MS, null);
+
+    // Team G (issue #214): open dispatcher-watchdog log sink, arm the 1 Hz
+    // PULSE timer, and — if the test-fixture env var is set — arm a one-shot
+    // timer that synthesises a stall so the log path can be verified.
+    const pid = std.os.windows.GetCurrentProcessId();
+    self.watchdog_log = DispatcherWatchdog.init(self.core_app.alloc, pid) catch |err| blk: {
+        log.warn("dispatcher-watchdog log init failed: {} — continuing log-less", .{err});
+        break :blk null;
+    };
+    self.last_pulse_t_ms.store(std.time.milliTimestamp(), .release);
+    _ = os.SetTimer(self.hwnd.?, DISPATCHER_PULSE_TIMER_ID, DISPATCHER_PULSE_INTERVAL_MS, null);
+    if (watchdogTestStallRequested(self.core_app.alloc)) {
+        log.warn("watchdog test-stall fixture active — UI thread will block for {d}ms after 5s", .{WATCHDOG_TEST_STALL_MS});
+        _ = os.SetTimer(self.hwnd.?, WATCHDOG_TEST_TRIGGER_TIMER_ID, 5_000, null);
+    }
+
     self.watchdog_thread = std.Thread.spawn(.{}, watchdogLoop, .{self}) catch |err| blk: {
         log.warn("watchdog spawn failed: {}", .{err});
         break :blk null;
     };
+}
+
+fn watchdogTestStallRequested(allocator: std.mem.Allocator) bool {
+    const value = std.process.getEnvVarOwned(allocator, "GHOSTTY_WINUI3_WATCHDOG_TEST_STALL") catch return false;
+    defer allocator.free(value);
+    return std.mem.eql(u8, value, "1") or
+        std.ascii.eqlIgnoreCase(value, "true") or
+        std.ascii.eqlIgnoreCase(value, "yes");
 }
 
 /// Background poller that detects UI-thread stalls by comparing now against
@@ -600,6 +647,9 @@ fn watchdogLoop(self: *App) void {
             self.last_ui_stall_ms.store(stall_ms, .release);
             if (!self.ui_stalled_reported.swap(true, .acq_rel)) {
                 log.warn("ui_stall detected stall_ms={} threshold_ms=3000", .{stall_ms});
+                if (self.watchdog_log) |wl| {
+                    wl.writeStall(stall_ms, self.last_pulse_t_ms.load(.acquire));
+                }
             }
         }
     }
@@ -1319,6 +1369,12 @@ pub fn terminate(self: *App) void {
     }
     if (self.hwnd) |h| {
         _ = os.KillTimer(h, HEARTBEAT_TIMER_ID);
+        _ = os.KillTimer(h, DISPATCHER_PULSE_TIMER_ID);
+        _ = os.KillTimer(h, WATCHDOG_TEST_TRIGGER_TIMER_ID);
+    }
+    if (self.watchdog_log) |wl| {
+        wl.deinit();
+        self.watchdog_log = null;
     }
     self.setExitIntent(.terminate);
     self.running = false;
@@ -1877,7 +1933,7 @@ fn controlPlaneCaptureTabList(ctx: *anyopaque, allocator: Allocator) !?[]u8 {
     errdefer buf.deinit(allocator);
     const writer = buf.writer(allocator);
     try writer.print("LIST_TABS|{d}|{d}\n", .{ tab_count, self.active_surface_idx });
-    
+
     var i: usize = 0;
     while (i < tab_count) : (i += 1) {
         if (self.getSurface(i)) |surface| {
@@ -1895,6 +1951,37 @@ fn controlPlaneCaptureTabList(ctx: *anyopaque, allocator: Allocator) !?[]u8 {
         }
     }
     return try buf.toOwnedSlice(allocator);
+}
+
+/// Team G (issue #214): CP WATCHDOG pull — returns current dispatcher-watchdog
+/// state so external monitors (deckpilot) can observe which session's UI
+/// thread is pumping. Single-line `OK|...` response, CRLF-free.
+fn controlPlaneCaptureWatchdog(ctx: *anyopaque, allocator: Allocator) ![]u8 {
+    const self: *App = @ptrCast(@alignCast(ctx));
+    const pid = std.os.windows.GetCurrentProcessId();
+    const last_hb_ns = self.last_ui_heartbeat_ns.load(.acquire);
+    const last_pulse_t_ms = self.last_pulse_t_ms.load(.acquire);
+    const last_stall_ms = self.last_ui_stall_ms.load(.acquire);
+    const stalled = self.ui_stalled_reported.load(.acquire);
+    const hb_age_ms: u64 = if (last_hb_ns == 0)
+        0
+    else blk: {
+        const delta: i128 = std.time.nanoTimestamp() - last_hb_ns;
+        if (delta < 0) break :blk 0;
+        break :blk @intCast(@divTrunc(delta, std.time.ns_per_ms));
+    };
+    return std.fmt.allocPrint(
+        allocator,
+        "OK|WATCHDOG|pid={d}|t_ms={d}|last_pulse_t_ms={d}|hb_age_ms={d}|stalled={d}|last_stall_ms={d}|threshold_ms=3000\n",
+        .{
+            pid,
+            std.time.milliTimestamp(),
+            last_pulse_t_ms,
+            hb_age_ms,
+            @as(u8, if (stalled) 1 else 0),
+            last_stall_ms,
+        },
+    );
 }
 
 // ---------------------------------------------------------------
@@ -2650,6 +2737,35 @@ fn handleTimer(self: *App, hwnd: os.HWND, wparam: os.WPARAM) os.LRESULT {
             // the stall-reported latch so a future re-stall can re-fire.
             self.last_ui_heartbeat_ns.store(std.time.nanoTimestamp(), .release);
             self.ui_stalled_reported.store(false, .release);
+            return 0;
+        },
+        DISPATCHER_PULSE_TIMER_ID => {
+            // Team G (issue #214): 1 Hz dispatcher pulse.
+            // `hb_age_ms` is the delta between now and the last 100ms
+            // heartbeat stamp, so a healthy pulse shows hb_age_ms < ~200.
+            const now_ns = std.time.nanoTimestamp();
+            const last_hb = self.last_ui_heartbeat_ns.load(.acquire);
+            const hb_age_ms: u64 = if (last_hb == 0)
+                0
+            else blk: {
+                const delta: i128 = now_ns - last_hb;
+                if (delta < 0) break :blk 0;
+                break :blk @intCast(@divTrunc(delta, std.time.ns_per_ms));
+            };
+            const stalled = self.ui_stalled_reported.load(.acquire);
+            self.last_pulse_t_ms.store(std.time.milliTimestamp(), .release);
+            if (self.watchdog_log) |wl| {
+                wl.writePulse(hb_age_ms, stalled);
+            }
+            return 0;
+        },
+        WATCHDOG_TEST_TRIGGER_TIMER_ID => {
+            // Dev fixture: one-shot — kill the timer and synthesise a UI-thread
+            // stall so the log sink and watchdog thread can be verified.
+            _ = os.KillTimer(hwnd, WATCHDOG_TEST_TRIGGER_TIMER_ID);
+            log.warn("watchdog test-stall: blocking UI thread for {d}ms", .{WATCHDOG_TEST_STALL_MS});
+            std.Thread.sleep(@as(u64, WATCHDOG_TEST_STALL_MS) * std.time.ns_per_ms);
+            log.warn("watchdog test-stall: resumed", .{});
             return 0;
         },
         CLOSE_TAB_POLL_TIMER_ID => {

--- a/src/apprt/winui3/control_plane.zig
+++ b/src/apprt/winui3/control_plane.zig
@@ -88,6 +88,10 @@ pub const ControlPlane = struct {
     pub const CaptureTailFn = *const fn (ctx: *anyopaque, allocator: Allocator, tab_idx: ?usize) anyerror!?[]u8;
     pub const CaptureHistoryFn = *const fn (ctx: *anyopaque, allocator: Allocator, tab_idx: ?usize) anyerror!?[]u8;
     pub const CaptureTabListFn = *const fn (ctx: *anyopaque, allocator: Allocator) anyerror!?[]u8;
+    /// Team G (issue #214): returns a single-line OK| payload describing the
+    /// current dispatcher-watchdog state. Callee must return allocator-owned
+    /// memory; pipeHandler will return it directly to the client.
+    pub const CaptureWatchdogFn = *const fn (ctx: *anyopaque, allocator: Allocator) anyerror![]u8;
 
     allocator: Allocator,
     hwnd: os.HWND,
@@ -114,6 +118,7 @@ pub const ControlPlane = struct {
     capture_tail_fn: ?CaptureTailFn = null,
     capture_history_fn: ?CaptureHistoryFn = null,
     capture_tab_list_fn: ?CaptureTabListFn = null,
+    capture_watchdog_fn: ?CaptureWatchdogFn = null,
     max_pending_inputs: usize = default_max_pending_inputs,
     max_inflight_data_requests: u32 = default_max_inflight_data_requests,
     inflight_data_requests: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
@@ -140,6 +145,7 @@ pub const ControlPlane = struct {
         capture_tail_fn: ?CaptureTailFn,
         capture_history_fn: ?CaptureHistoryFn,
         capture_tab_list_fn: ?CaptureTabListFn,
+        capture_watchdog_fn: ?CaptureWatchdogFn,
     ) !*ControlPlane {
         const self = try allocator.create(ControlPlane);
         errdefer allocator.destroy(self);
@@ -152,6 +158,7 @@ pub const ControlPlane = struct {
             .capture_tail_fn = capture_tail_fn,
             .capture_history_fn = capture_history_fn,
             .capture_tab_list_fn = capture_tab_list_fn,
+            .capture_watchdog_fn = capture_watchdog_fn,
         };
         self.cache.ttl_ns = self.loadCacheTtlNs();
         self.max_pending_inputs = self.loadMaxPendingInputs();
@@ -237,6 +244,20 @@ pub const ControlPlane = struct {
                 },
             ) catch return "ERR|oom\n";
         }
+        // Team G (issue #214): WATCHDOG pull command — returns current
+        // dispatcher-watchdog state (pulse / stall) to external monitors.
+        // deckpilot polls this to detect which session's UI thread is stuck.
+        if (std.ascii.eqlIgnoreCase(commandName(req), "WATCHDOG")) {
+            if (self.capture_watchdog_fn) |fn_ptr| {
+                if (self.callback_ctx) |cbx| {
+                    return fn_ptr(cbx, allocator) catch |err| blk: {
+                        log.warn("WATCHDOG capture failed: {}", .{err});
+                        break :blk allocator.dupe(u8, "ERR|watchdog_capture_failed\n") catch "ERR|watchdog_capture_failed\n";
+                    };
+                }
+            }
+            return allocator.dupe(u8, "ERR|watchdog_unavailable\n") catch "ERR|watchdog_unavailable\n";
+        }
         if (self.cp) |*cp| {
             return self.handleRequestWith(request, allocator, cp, cpBackend);
         }
@@ -255,7 +276,7 @@ pub const ControlPlane = struct {
         if (std.mem.eql(u8, cmd, "CAPABILITIES")) {
             return std.fmt.allocPrint(
                 allocator,
-                "OK|{s}|CAPABILITIES|transport=polling|reads=STATE,CAPTURE_PANE,TAIL,HISTORY,WAIT_FOR,PANE_PID,CURSOR_POS,PANE_TITLE,LIST_TABS|writes=INPUT,RAW_INPUT,PASTE,SEND_KEYS,ACK_POLL|control=NEW_TAB,CLOSE_TAB,SWITCH_TAB,FOCUS\n",
+                "OK|{s}|CAPABILITIES|transport=polling|reads=STATE,CAPTURE_PANE,TAIL,HISTORY,WAIT_FOR,PANE_PID,CURSOR_POS,PANE_TITLE,LIST_TABS,WATCHDOG|writes=INPUT,RAW_INPUT,PASTE,SEND_KEYS,ACK_POLL|control=NEW_TAB,CLOSE_TAB,SWITCH_TAB,FOCUS\n",
                 .{self.session_name orelse "ghostty"},
             ) catch "ERR|oom\n";
         }

--- a/src/apprt/winui3/watchdog.zig
+++ b/src/apprt/winui3/watchdog.zig
@@ -1,0 +1,139 @@
+//! Dispatcher watchdog log sink for the WinUI3 apprt (Team G, issue #214).
+//!
+//! Writes per-pid pulse/stall events to a log file that external monitors
+//! (e.g. deckpilot) can tail to determine whether the UI-thread dispatcher
+//! of a given Ghostty session is still pumping.
+//!
+//! File path: `%LOCALAPPDATA%\ghostty\dispatcher-watchdog-<pid>.log`
+//!
+//! Line format (one event per line, ASCII, CRLF-free):
+//!   PULSE t_ms=<unix_ms> pid=<u32> hb_age_ms=<u64> stalled=<0|1>
+//!   STALL t_ms=<unix_ms> pid=<u32> elapsed_ms=<u64> last_pulse_t_ms=<unix_ms>
+//!   # <free-form comment> (session_start / session_end markers)
+//!
+//! Design goals:
+//!   * UI-thread writes (PULSE) are cheap: bounded-stack format buffer, one
+//!     `WriteFile` per tick, no allocation on the hot path.
+//!   * Watchdog-thread writes (STALL) are serialised against PULSE via a
+//!     mutex so interleaved ticks never truncate each other.
+//!   * `FlushFileBuffers` after every write: if the process crashes between
+//!     ticks, the last pulse is on disk already — that is how an external
+//!     monitor distinguishes a crash from a stall.
+
+const std = @import("std");
+const os = @import("os.zig");
+const Allocator = std.mem.Allocator;
+
+const log = std.log.scoped(.winui3_watchdog);
+
+pub const DispatcherWatchdog = struct {
+    allocator: Allocator,
+    file: std.fs.File,
+    path: []u8,
+    pid: u32,
+    mutex: std.Thread.Mutex = .{},
+
+    /// Open (or create + append) the per-pid log file under %LOCALAPPDATA%\ghostty.
+    /// Returns a heap-allocated DispatcherWatchdog so the watchdog background
+    /// thread can access it safely via a stable pointer.
+    pub fn init(allocator: Allocator, pid: u32) !*DispatcherWatchdog {
+        const local_appdata = try std.process.getEnvVarOwned(allocator, "LOCALAPPDATA");
+        defer allocator.free(local_appdata);
+
+        const dir = try std.fs.path.join(allocator, &.{ local_appdata, "ghostty" });
+        defer allocator.free(dir);
+        std.fs.cwd().makePath(dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
+
+        const file_name = try std.fmt.allocPrint(allocator, "dispatcher-watchdog-{d}.log", .{pid});
+        defer allocator.free(file_name);
+        const path = try std.fs.path.join(allocator, &.{ dir, file_name });
+        errdefer allocator.free(path);
+
+        var file = std.fs.openFileAbsolute(path, .{ .mode = .read_write }) catch blk: {
+            break :blk try std.fs.createFileAbsolute(path, .{ .truncate = false, .read = true });
+        };
+        errdefer file.close();
+        file.seekFromEnd(0) catch |err| {
+            log.warn("seekFromEnd failed: {}", .{err});
+        };
+
+        const self = try allocator.create(DispatcherWatchdog);
+        self.* = .{
+            .allocator = allocator,
+            .file = file,
+            .path = path,
+            .pid = pid,
+        };
+
+        const now_ms = std.time.milliTimestamp();
+        self.writeLine("# session_start pid={d} t_ms={d}\n", .{ pid, now_ms });
+        log.info("watchdog log opened path={s}", .{path});
+        return self;
+    }
+
+    pub fn deinit(self: *DispatcherWatchdog) void {
+        const now_ms = std.time.milliTimestamp();
+        self.writeLine("# session_end pid={d} t_ms={d}\n", .{ self.pid, now_ms });
+
+        self.mutex.lock();
+        self.file.close();
+        self.mutex.unlock();
+
+        self.allocator.free(self.path);
+        self.allocator.destroy(self);
+    }
+
+    /// 1 Hz pulse from the UI thread — emits a PULSE entry.
+    /// `heartbeat_age_ms` is the delta between now and the last ~100ms
+    /// `HEARTBEAT_TIMER_ID` stamp, which reflects actual dispatcher latency.
+    pub fn writePulse(
+        self: *DispatcherWatchdog,
+        heartbeat_age_ms: u64,
+        stalled: bool,
+    ) void {
+        const now_ms = std.time.milliTimestamp();
+        self.writeLine("PULSE t_ms={d} pid={d} hb_age_ms={d} stalled={d}\n", .{
+            now_ms,
+            self.pid,
+            heartbeat_age_ms,
+            @as(u8, if (stalled) 1 else 0),
+        });
+    }
+
+    /// Called from the watchdog background thread when the UI-thread
+    /// heartbeat has gone stale for >= threshold.
+    pub fn writeStall(
+        self: *DispatcherWatchdog,
+        elapsed_ms: u64,
+        last_pulse_t_ms: i64,
+    ) void {
+        const now_ms = std.time.milliTimestamp();
+        self.writeLine("STALL t_ms={d} pid={d} elapsed_ms={d} last_pulse_t_ms={d}\n", .{
+            now_ms,
+            self.pid,
+            elapsed_ms,
+            last_pulse_t_ms,
+        });
+    }
+
+    fn writeLine(self: *DispatcherWatchdog, comptime fmt: []const u8, args: anytype) void {
+        var buf: [512]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, fmt, args) catch |err| {
+            log.warn("bufPrint failed: {}", .{err});
+            return;
+        };
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.file.writeAll(msg) catch |err| {
+            log.warn("writeAll failed: {}", .{err});
+            return;
+        };
+        // Best-effort flush so a crash does not swallow the last pulse.
+        _ = os.FlushFileBuffers(self.file.handle);
+    }
+};


### PR DESCRIPTION
> この記事はAIによって起草されました。

Closes #214 (observability increment — does **not** fix the underlying XAML dispatcher deadlock; adds the instrumentation needed to localize it under multi-session load).

## What this adds

Extends the Tier 1 UI-thread heartbeat shipped in #212 (`54479af8c`) with two external-observable channels so an out-of-process monitor (deckpilot) can tell **which** WinUI3 session's dispatcher has frozen:

1. **Per-pid log sink** — `%LOCALAPPDATA%\ghostty\dispatcher-watchdog-<pid>.log`, ASCII, `FlushFileBuffers` after each write.
   - `PULSE t_ms=<unix_ms> pid=<u32> hb_age_ms=<u64> stalled=<0|1>` at 1 Hz from the UI thread.
   - `STALL t_ms=<unix_ms> pid=<u32> elapsed_ms=<u64> last_pulse_t_ms=<unix_ms>` from the background watchdog thread when the 100ms heartbeat is stale ≥ 3s.
   - `# session_start` / `# session_end` markers bracket the session.
2. **CP-pipe pull command `WATCHDOG`** returning the same state inline:
   `OK|WATCHDOG|pid=<u32>|t_ms=<unix_ms>|last_pulse_t_ms=<unix_ms>|hb_age_ms=<u64>|stalled=<0|1>|last_stall_ms=<u64>|threshold_ms=3000`.
   `CAPABILITIES` `reads=` list now advertises `WATCHDOG` for feature detection. Pull-only — `zig-control-plane`'s push/event API was removed in a prior refactor (see #212 commit body).
3. **Dev fixture** — `GHOSTTY_WINUI3_WATCHDOG_TEST_STALL=1` arms a one-shot 5s-after-init UI-thread `Sleep(5000)` so the stall path can be exercised without real load. Never armed in production.

Tier 1 heartbeat semantics (threshold = 3s, 100ms stamp cadence, per-stall debouncing) are preserved — the new code feeds `writeStall` from the existing `watchdogLoop`, no timing logic was altered.

## Files

| File | Change |
|---|---|
| `src/apprt/winui3/watchdog.zig` | **New.** `DispatcherWatchdog` — mutex-guarded per-pid log file, `writePulse` / `writeStall` / `deinit`. |
| `src/apprt/winui3/App.zig` | Wire 1 Hz pulse timer + one-shot dev-fixture timer; open/close `watchdog_log`; feed `writeStall` from `watchdogLoop`; `controlPlaneCaptureWatchdog`; pass fn to `ControlPlaneNative.create`. |
| `src/apprt/winui3/control_plane.zig` | `CaptureWatchdogFn` type + field; extend `create(...)`; intercept `WATCHDOG` in `pipeHandler`; add `WATCHDOG` to `CAPABILITIES` reads. |
| `.dispatch/watchdog_probe.ps1` | **New.** PowerShell smoke probe used during verification (`CAPABILITIES` + `WATCHDOG` over the named pipe). |
| `.dispatch/team-g-winui3-dispatcher-watchdog-{brief,report}.md` | **New.** Dispatch brief + verification report. |

## Evidence — three live hangs observed in the session that produced this PR

Same shape as the table in #214 body. All three were recovered via `taskkill`; graceful `ESC` / `Ctrl+C` via deckpilot all failed with `phase1_timeout`, confirming the stall is in ghostty's XAML input path, not the child `claude.exe`.

| session PID | task | hang @ elapsed | trigger |
|---|---|---|---|
| 2176 | Claude executing long SBCL test run | 4m 37s (timer frozen) | ≥3 peer sessions active |
| 48692 | Claude on Rust `cargo build` + edit loop | 9m 51s (timer frozen) | 4 peer sessions active |
| 23792 | Claude finalizing fiveam + puppeteer E2E | 39m 15s (timer frozen) | 4 peer sessions active |

**After this PR** an identical hang would produce a `dispatcher-watchdog-<pid>.log` with the last `PULSE` dated to the freeze moment and a `STALL elapsed_ms=…` line, plus `deckpilot` polling `WATCHDOG` would see `stalled=1, hb_age_ms ≫ 3000` on the frozen session while peers stay `stalled=0`. That is exactly the signal needed to separate "XAML dispatcher deadlock" from "claude.exe stuck thinking" — which is the ambiguity that makes #214 hard to triage today.

### Verification output (dev fixture, excerpt)

```
# session_start pid=47652 t_ms=1776692584159
PULSE t_ms=1776692585163 pid=47652 hb_age_ms=20 stalled=0
PULSE t_ms=1776692586163 pid=47652 hb_age_ms=32 stalled=0
PULSE t_ms=1776692587161 pid=47652 hb_age_ms=48 stalled=0
PULSE t_ms=1776692588182 pid=47652 hb_age_ms=79 stalled=0
STALL t_ms=1776692592167 pid=47652 elapsed_ms=3085 last_pulse_t_ms=1776692588182
PULSE t_ms=1776692594168 pid=47652 hb_age_ms=5086 stalled=1
PULSE t_ms=1776692594175 pid=47652 hb_age_ms=3  stalled=0
```

`STALL` fires at `elapsed_ms=3085` — the first 1 Hz tick past the 3000 ms threshold, as designed. First post-stall `PULSE` correctly echoes the latched `stalled=1` before the heartbeat timer re-stamps. Idle-load CP pull under a separate run returned `hb_age_ms=17, stalled=0` — see `.dispatch/team-g-winui3-dispatcher-watchdog-report.md` §Verification for the full probe.

## Known merge conflict (reviewer must resolve by hand)

`src/apprt/winui3/App.zig` will conflict against **e4d99ae8b `merge: P0 #4 Config.load cache + async reload`** already on `feat/ui-hang-resilience-integration`. Both changesets touch the same region of `App.init` / app-lifecycle init path:

- **This PR**: inserts watchdog log open + 1 Hz pulse timer registration + optional dev-fixture timer registration, and matching teardown in `terminate`.
- **P0 #4**: restructured `Config.load` to populate a cache and spawn the async reload worker in the same init prologue.

The two sides were developed in parallel worktrees and neither rebased onto the other. Both additions are orthogonal in intent — watchdog is pure observability, Config.load cache is config hot-reload — so the correct resolution is "keep both"; the only decision is ordering (watchdog first so a hang during async config reload is itself observable — recommended). Reviewer merge via the GitHub UI will flag the conflict; resolve locally with `git merge origin/feat/ui-hang-resilience-integration`, keep both hunks, rebuild with `./build-winui3.sh`, then merge the PR.

No other files conflict.

## Dogfooding note

The Team G session that landed this commit (**ghostty-34660**) hung at the "commit, push, write report" step at **24m 06s elapsed, "Thinking…" timer frozen**, `deckpilot send` returning `phase1_timeout` — **the exact signature of #214**, reproduced during the PR-authoring work for the fix to #214. Main-thread opus had to `taskkill` the session and push the already-landed commit from the host shell. Had this PR's watchdog been active, `dispatcher-watchdog-34660.log` would have preserved a `STALL` line + the last `PULSE` at the freeze moment — which is exactly the evidence #214 currently lacks. The self-referential data point is itself the strongest argument for landing this increment.

## Out of scope

- **4-session concurrent repro** — explicit non-goal of the originating brief; the watchdog contract alone is proven by the fixture, and multi-session repro belongs in a separate stress-test ticket.
- **Log rotation** — single-file per pid, deckpilot tails + truncates out of band. Follow-up if sessions routinely run >1 day.
- **CP push** — `zig-control-plane` no longer exposes an event/push thread; polling consumer accepts ≤1s detection lag.
- **Win32 apprt comparison** — deferred; WinUI3-specific observability only.

See `.dispatch/team-g-winui3-dispatcher-watchdog-report.md` §"Known gaps / follow-ups" for the full list.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)