### PR TITLE
fix(winui3): post WM_USER on wakeup CAS-contention to break self-deadlock

### DIFF
--- a/src/apprt/winui3/App.zig
+++ b/src/apprt/winui3/App.zig
@@ -1586,7 +1586,17 @@ pub fn wakeup(self: *App) void {
         // Coalesce: if a drainMailbox is already scheduled, skip TryEnqueue.
         // drainMailbox clears the flag at entry, so any wakeup during tick
         // will re-arm this path and schedule a fresh drain.
-        if (self.wakeup_pending.cmpxchgStrong(false, true, .acq_rel, .monotonic)) |_| return;
+        if (self.wakeup_pending.cmpxchgStrong(false, true, .acq_rel, .monotonic)) |_| {
+            // Someone else already scheduled a drain, but we cannot prove the
+            // dispatcher callback will actually fire (shutdown race, COM
+            // reentry cancellation, spurious drop). Post WM_USER as a
+            // belt-and-suspenders fallback: Windows coalesces posted messages
+            // per-window/per-message, so this does not re-flood the
+            // Dispatcher while still guaranteeing at least one delivery path
+            // survives callback-dropped races.
+            if (self.hwnd) |hwnd| _ = postMessageWarn(hwnd, os.WM_USER, 0, 0, "WM_USER");
+            return;
+        }
         WakeupHandler.g_app.store(self, .release);
         _ = dq.tryEnqueue(@ptrCast(&WakeupHandler.instance)) catch {
             // TryEnqueue failed — clear the flag so future wakeups retry,


### PR DESCRIPTION
## Regression from #214

commit 00beecf28 introduced a self-deadlock. Every new ghostty.exe spawn today hangs: MainWindowTitle gets set but `Responding=False`, CP pipe server never begins listening. The pre-existing instance from 8:14 AM (started before the binary rebuild at 00:25) happened to skirt the race and is still alive.

## Root cause

`src/apprt/winui3/App.zig` L1589 — `wakeup()` early-returns on CAS contention, but the path that won the CAS (set `wakeup_pending=true`, `TryEnqueue`'d a drain) has no guarantee the dispatcher callback will actually fire.

If `TryEnqueue` succeeds but the callback is dropped (shutdown race, COM reentry cancellation, spurious drop), `wakeup_pending` stays true forever. Every subsequent `wakeup()` hits the L1589 early-return. `drainMailbox` never runs → `core_app.tick` never advances → surface init stuck → CP pipe server never listens.

Matches the observed symptom precisely:
- Window + title created (apprt `init` / `initXaml` completed)
- UI pump live (WM_TIMER heartbeat fires — Tier1 watchdog reports no stall)
- Dispatcher queue frozen (drainMailbox never invoked)
- CP pipe server not listening

## Fix

On CAS contention, still post `WM_USER` to the window before returning. Windows coalesces posted messages per-window/per-message, so the Dispatcher flood benefit of #214 is preserved — we do not re-flood the dispatcher queue. But we guarantee at least one delivery path survives callback-dropped races: if the in-flight callback drops, the `WM_USER` message still wakes `drainMailbox` which clears `wakeup_pending`.

11 lines, one additional branch with comment.

## Interaction with Tier1 watchdog (#212)

Tier1 watchdog heartbeat is driven by `WM_TIMER` (HEARTBEAT_TIMER_ID), which fires independently of `drainMailbox`. It therefore cannot detect this failure mode (heartbeat stays fresh) and has no recovery action regardless — it's observation-only. This fix is the sole automatic recovery path until a dedicated watchdog-driven recovery is added.

## Verification

Debug build (this branch) progresses past the previous hang point:
- App.init: EXIT OK ✓
- initXaml: START → NonClientIslandWindow created ✓
- dispatcher init → reaches shell-launch phase ✓ (previous regression: stuck before initXaml completes)

Unrelated debug-only `logFmt` crash surfaces in `termio/Exec.zig:937` on JP locale debug builds (pre-existing, out of scope for this PR). ReleaseSafe build + spawn-test is pending and will be posted as a follow-up comment.

## Scope

- Single file: `src/apprt/winui3/App.zig`
- 11 insertions, 1 deletion
- No behavior change on the happy path (first wakeup through)
- New behavior only on CAS contention: send a WM_USER before returning (effectively free due to Windows message coalescing)

Co-Authored-By: Claude Opus 4.7 (1M context)