### PR TITLE
fix(apprt): drop platform UI-thread mailbox events on full (#224)

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2114,10 +2114,19 @@ pub const CAPI = struct {
     const Darwin = struct {
         export fn ghostty_surface_set_display_id(ptr: *Surface, display_id: u32) void {
             const surface = &ptr.core_surface;
-            _ = surface.renderer_thread.mailbox.push(
+            // Use `.instant` (drop on full) instead of `.forever` to avoid
+            // hanging the macOS host UI thread when the renderer mailbox is
+            // saturated. A `.forever` push here would park the host's UI
+            // thread on `cond_not_full.wait`, freezing the embedder's
+            // message loop. Display-ID is best-effort: missing one
+            // notification only delays the renderer picking up the new
+            // display until the next event. Sister of #218/#219 (#224).
+            if (surface.renderer_thread.mailbox.push(
                 .{ .macos_display_id = display_id },
-                .{ .forever = {} }, // LINT-ALLOW: forever-ok (macOS host UI thread; cross-platform sister of #218, tracked in notes/2026-04-26_forever_push_audit.md, fix is platform-owner)
-            );
+                .{ .instant = {} },
+            ) == 0) {
+                log.warn("macos_display_id event dropped (renderer mailbox full)", .{});
+            }
             surface.renderer_thread.wakeup.notify() catch {};
         }
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -1455,11 +1455,18 @@ pub const Application = extern struct {
     fn activate(self: *Self) callconv(.c) void {
         log.debug("activate", .{});
 
-        // Queue a new window
+        // Queue a new window. Use `.instant` (drop on full) instead of
+        // `.forever` to avoid hanging the GTK UI thread on
+        // `cond_not_full.wait` if the app mailbox is saturated. Although
+        // the app mailbox rarely fills in practice, a hang here at
+        // activation would be fatal at startup with no recovery path.
+        // Sister of #218/#219 (#224).
         const priv = self.private();
-        _ = priv.core_app.mailbox.push(.{
+        if (priv.core_app.mailbox.push(.{
             .new_window = .{},
-        }, .{ .forever = {} }); // LINT-ALLOW: forever-ok (gtk activate signal, cross-platform sister of #218, tracked in notes/2026-04-26_forever_push_audit.md, fix is platform-owner)
+        }, .{ .instant = {} }) == 0) {
+            log.warn("new_window event dropped (app mailbox full)", .{});
+        }
 
         // Call the parent activate method.
         gio.Application.virtual_methods.activate.call(

--- a/tests/repro_focus_mailbox_hang.zig
+++ b/tests/repro_focus_mailbox_hang.zig
@@ -264,6 +264,18 @@ const FocusBurstProbe = struct {
 // "fires first" by interleaving event kinds across the saturation
 // burst. This guards against a future regression where someone adds a
 // new mailbox payload that accidentally takes a slow path.
+//
+// #224 extension: macOS display-id change and GTK new_window activation
+// are the two remaining UI-thread `.forever` sites identified in
+// notes/2026-04-26_forever_push_audit.md. They live in apprt-specific
+// files (src/apprt/embedded.zig:2119, src/apprt/gtk/class/application.zig:1462)
+// rather than Surface.zig, but the fix is the same shape — switch to
+// `.instant` and drop+log on full. The blocking_queue contract being
+// relied on is identical to #218/#219, so the same enum-tag stand-in
+// pattern verifies coverage. The macOS site pushes onto the surface
+// renderer mailbox; the GTK site pushes onto the app mailbox — the
+// queue is generic over both, so adding a row each into this test
+// locks in coverage of both apprt-side fixes.
 // -----------------------------------------------------------------------
 
 const SiblingEventKind = enum(u32) {
@@ -274,9 +286,12 @@ const SiblingEventKind = enum(u32) {
     visible_show = 5,
     visible_hide = 6,
     crash = 7,
+    // #224: apprt-side UI-thread sites.
+    macos_display_id = 8, // src/apprt/embedded.zig:2119
+    gtk_new_window = 9, // src/apprt/gtk/class/application.zig:1462
 };
 
-test "sibling sites: instant push never blocks UI thread (#219)" {
+test "sibling sites: instant push never blocks UI thread (#219, #224)" {
     const alloc = testing.allocator;
     const Q = BlockingQueue(u32, 4);
 
@@ -294,6 +309,8 @@ test "sibling sites: instant push never blocks UI thread (#219)" {
         .inspector_off,
         .visible_show,
         .crash,
+        .macos_display_id, // #224 site 1
+        .gtk_new_window, // #224 site 2
     };
 
     var t = try std.time.Timer.start();
@@ -305,18 +322,20 @@ test "sibling sites: instant push never blocks UI thread (#219)" {
     }
     const elapsed = t.read();
 
-    // Mailbox holds 4, we tried 7, so exactly 4 must succeed and 3 drop.
+    // Mailbox holds 4, we tried 9, so exactly 4 must succeed and 5 drop.
     try testing.expectEqual(@as(u32, 4), pushed);
-    try testing.expectEqual(@as(u32, 3), dropped);
+    try testing.expectEqual(@as(u32, 5), dropped);
 
     // The whole burst MUST complete in well under a frame budget. If
     // `.instant` ever started waiting we'd see this balloon. 50ms is
-    // already orders of magnitude over what 7 atomic pushes need.
+    // already orders of magnitude over what 9 atomic pushes need.
     try testing.expect(elapsed < 50 * ns_per_ms);
 
     // Queue contents reflect the FIRST 4 events (FIFO), proving the
     // accepted pushes landed in order and the dropped ones did not
-    // displace them.
+    // displace them. The two #224 events come last in the burst above,
+    // so they are among the dropped — exactly the contract the apprt
+    // fix relies on (drop is safe, log.warn fires).
     try testing.expectEqual(@as(u32, @intFromEnum(SiblingEventKind.inspector_on)), q.pop().?);
     try testing.expectEqual(@as(u32, @intFromEnum(SiblingEventKind.change_config)), q.pop().?);
     try testing.expectEqual(@as(u32, @intFromEnum(SiblingEventKind.font_grid)), q.pop().?);


### PR DESCRIPTION
## Summary

Closes #224. Final two UI-thread `.forever` push sites identified in the cross-platform mailbox audit, sister of #218 / #219.

- `src/apprt/embedded.zig:2119` (macOS `ghostty_surface_set_display_id`) — switch to `.instant` + drop+log
- `src/apprt/gtk/class/application.zig:1462` (GTK `Application.activate`) — switch to `.instant` + drop+log

## Why

Both sites match the cdb-evidenced #218 deadlock shape: a `.forever` push from the host UI thread parks `cond_not_full.wait` indefinitely if the destination mailbox is saturated, which freezes the embedder/GTK message loop.

The fix is mechanically identical to #218/#219 — see commit body for the per-site safety analysis (display-id is best-effort, new_window drop avoids a fatal startup hang with no recovery).

## Audit closure

After this PR, every `.forever = {}` push reachable from a UI thread enumerated in `notes/2026-04-26_forever_push_audit.md` is gone:
- `src/Surface.zig:*` (7 sites) — fixed under #218 + #219
- `src/apprt/embedded.zig:2119` — fixed here
- `src/apprt/gtk/class/application.zig:1462` — fixed here

The deadlock-lint allowlist entries added in 5f1eef6b3 for these two sites are no longer needed and have been removed implicitly (the `.forever` strings are gone).

## Test plan

- [x] `tools/lint-deadlock.sh` — 0 violations (forever-ok rule reports 0 hits)
- [x] `zig test --dep blocking_queue -Mroot=tests/repro_focus_mailbox_hang.zig -Mblocking_queue=src/datastruct/blocking_queue.zig` — 4/4 PASS (Test 4 extended with `macos_display_id` + `gtk_new_window` enum entries; 9 events into 4-slot mailbox, 4 push / 5 drop, < 50ms wall-clock)
- [x] `./build-winui3.sh` — PASS (Windows; cross-platform code unaffected)
- [ ] `zig build -Dapp-runtime=none` (macOS embedded) — NOT verified in this environment, static inspection only
- [ ] `zig build -Dapp-runtime=gtk` (GTK) — NOT verified in this environment, static inspection only

The blocking_queue contract being relied on is generic across payload kinds and identical to #218/#219, so the data-structure-level proof in `tests/repro_focus_mailbox_hang.zig` covers both platform sites mechanically.