### PR TITLE
feat(winui3): KS_NO_ACTIVATE=visible — show window without stealing focus (#247)

### DIFF
--- a/src/apprt/winui3/App.zig
+++ b/src/apprt/winui3/App.zig
@@ -67,6 +67,96 @@ const IMECoordinateCache = struct {
 
 const log = std.log.scoped(.winui3);
 
+/// Launch-time window-activation policy controlled by the
+/// `KS_NO_ACTIVATE` environment variable. See the long-form comment in
+/// `initXaml` step 5 for the rationale; the parser lives at module
+/// scope so unit tests can drive it directly without booting the
+/// WinUI3 runtime.
+pub const NoActivateMode = enum { default, hide, visible };
+
+/// Parse one `KS_NO_ACTIVATE` env-var value into a `NoActivateMode`.
+/// Pure function — no I/O, no allocator, no globals — so the unit
+/// test below can exhaustively cover the alias matrix:
+///
+///   `1` / `true` / `hide`            → `.hide`
+///   `visible` / `show` / `background`→ `.visible`
+///   anything else (incl. `0`, ``)    → `.default`
+///
+/// All matches are case-insensitive except the literal `1` (the
+/// existing UIA suite contract specifies decimal `1`, not `01` or
+/// other variants). Unknown values fall back to `.default` rather
+/// than failing closed: an operator typo should not make an
+/// interactive launch silently invisible.
+pub fn parseNoActivateMode(raw: []const u8) NoActivateMode {
+    if (std.mem.eql(u8, raw, "1") or
+        std.ascii.eqlIgnoreCase(raw, "true") or
+        std.ascii.eqlIgnoreCase(raw, "hide"))
+    {
+        return .hide;
+    }
+    if (std.ascii.eqlIgnoreCase(raw, "visible") or
+        std.ascii.eqlIgnoreCase(raw, "show") or
+        std.ascii.eqlIgnoreCase(raw, "background"))
+    {
+        return .visible;
+    }
+    return .default;
+}
+
+/// Read `KS_NO_ACTIVATE` from the process environment and dispatch
+/// through `parseNoActivateMode`. Wraps the I/O so the call site in
+/// `initXaml` stays one line; missing env var maps to `.default`.
+fn readNoActivateMode(alloc: Allocator) NoActivateMode {
+    const raw = std.process.getEnvVarOwned(alloc, "KS_NO_ACTIVATE") catch return .default;
+    defer alloc.free(raw);
+    return parseNoActivateMode(raw);
+}
+
+test "parseNoActivateMode: hide aliases" {
+    const expectEqual = std.testing.expectEqual;
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("1"));
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("true"));
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("True"));
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("TRUE"));
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("hide"));
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("Hide"));
+    try expectEqual(NoActivateMode.hide, parseNoActivateMode("HIDE"));
+}
+
+test "parseNoActivateMode: visible aliases" {
+    const expectEqual = std.testing.expectEqual;
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("visible"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("Visible"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("VISIBLE"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("show"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("Show"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("background"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("Background"));
+    try expectEqual(NoActivateMode.visible, parseNoActivateMode("BACKGROUND"));
+}
+
+test "parseNoActivateMode: unknown values fall back to default" {
+    const expectEqual = std.testing.expectEqual;
+    try expectEqual(NoActivateMode.default, parseNoActivateMode(""));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("0"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("false"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("no"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("typo"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("01"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("2"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("hidden")); // not "hide"
+}
+
+test "parseNoActivateMode: hide and visible never overlap" {
+    // Defensive: a typo halfway between the two ("show1") must not
+    // accidentally match the `hide` arm via the literal `1` check.
+    // The literal `1` is whole-string only.
+    const expectEqual = std.testing.expectEqual;
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("show1"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("1show"));
+    try expectEqual(NoActivateMode.default, parseNoActivateMode("hide1"));
+}
+
 fn postMessageWarn(hwnd: os.HWND, msg: os.UINT, wparam: os.WPARAM, lparam: os.LPARAM, msg_name: []const u8) bool {
     const result = os.PostMessageW(hwnd, msg, wparam, lparam);
     if (result == 0) {
@@ -594,10 +684,51 @@ fn initXaml(self: *App) !void {
     }
 
     // Step 5: Show the window.
-    _ = os.ShowWindow(self.hwnd.?, os.SW_SHOWNORMAL);
-    _ = os.UpdateWindow(self.hwnd.?);
-    _ = os.SetForegroundWindow(self.hwnd.?);
-    log.debug("initXaml step 5: ShowWindow + SetForegroundWindow OK", .{});
+    //
+    // `KS_NO_ACTIVATE` env var controls launch-time activation. The
+    // default (env unset) is unchanged: `SW_SHOWNORMAL` plus
+    // `SetForegroundWindow` so an interactive launch ends up focused.
+    // Two opt-in modes exist for non-interactive callers:
+    //
+    //   `KS_NO_ACTIVATE=hide` (also `1` / `true`)
+    //       → `SW_HIDE`. Window is invisible. The HWND stays alive
+    //         so UIA / CP / SendMessage automation can still drive it.
+    //         Used by the UIA suite and the cascade-deadlock repro
+    //         (`tests/winui3/test-helpers.psm1`) where popping a
+    //         window on top of the developer's interactive work
+    //         would be intrusive.
+    //
+    //   `KS_NO_ACTIVATE=visible` (also `show` / `background`)
+    //       → `SW_SHOWNOACTIVATE`. Window is visible at normal size,
+    //         taskbar entry appears, but foreground / focus stays
+    //         with whatever process had it before launch. Used by
+    //         background batch launchers (deckpilot e2e tests,
+    //         scripted spawn-many) where the operator wants to see
+    //         the window land but does not want their typing
+    //         redirected mid-stream.
+    const no_activate_mode: NoActivateMode = readNoActivateMode(self.core_app.alloc);
+    switch (no_activate_mode) {
+        .hide => {
+            _ = os.ShowWindow(self.hwnd.?, os.SW_HIDE);
+            _ = os.UpdateWindow(self.hwnd.?);
+            log.debug("initXaml step 5: ShowWindow(HIDE) — KS_NO_ACTIVATE=hide", .{});
+        },
+        .visible => {
+            // SW_SHOWNOACTIVATE: visible at normal size, no
+            // SetForegroundWindow follow-up — focus stays with the
+            // previously-foreground window. Taskbar entry appears
+            // so a human can click into the window if they want.
+            _ = os.ShowWindow(self.hwnd.?, os.SW_SHOWNOACTIVATE);
+            _ = os.UpdateWindow(self.hwnd.?);
+            log.debug("initXaml step 5: ShowWindow(SHOWNOACTIVATE) — KS_NO_ACTIVATE=visible", .{});
+        },
+        .default => {
+            _ = os.ShowWindow(self.hwnd.?, os.SW_SHOWNORMAL);
+            _ = os.UpdateWindow(self.hwnd.?);
+            _ = os.SetForegroundWindow(self.hwnd.?);
+            log.debug("initXaml step 5: ShowWindow + SetForegroundWindow OK", .{});
+        },
+    }
     self.setStartupStage(.window_activated);
 
     // Step 6: Create XAML content (TabView + SwapChainPanel).

--- a/src/apprt/winui3/os.zig
+++ b/src/apprt/winui3/os.zig
@@ -129,7 +129,20 @@ pub const SW_HIDE: c_int = 0;
 pub const SW_SHOWNORMAL: c_int = 1;
 pub const SW_SHOWMINIMIZED: c_int = 2;
 pub const SW_SHOWMAXIMIZED: c_int = 3;
+/// SW_SHOWNOACTIVATE — visible at normal size, but does NOT take the
+/// foreground / focus. Taskbar entry appears; the previously-active
+/// window keeps keyboard focus. Used by `KS_NO_ACTIVATE=visible` (and
+/// alias `=show`) for the "background batch launch" case where the
+/// caller wants the window discoverable but doesn't want to steal
+/// focus from the user's interactive work (deckpilot e2e tests,
+/// scripted spawn-many).
+pub const SW_SHOWNOACTIVATE: c_int = 4;
 pub const SW_SHOW: c_int = 5;
+/// SW_SHOWNA — visible, no activation, no z-order change. Distinct
+/// from SHOWNOACTIVATE in that the latter restores the window if it
+/// was minimised; SHOWNA leaves it as-is. Both have "do not focus"
+/// semantics; we use SHOWNOACTIVATE because we always start hidden.
+pub const SW_SHOWNA: c_int = 8;
 pub const PM_REMOVE: UINT = 0x0001;
 pub const PM_NOREMOVE: UINT = 0x0000;
 pub const GWLP_USERDATA: c_int = -21;

--- a/tests/winui3/run-single-test.ps1
+++ b/tests/winui3/run-single-test.ps1
@@ -12,7 +12,10 @@ if (-not $ExePath) {
 }
 
 # Standalone tests (Phase 3) manage their own process — don't launch ghostty for them.
-$standaloneTests = @("test-05-ghost-demo")
+$standaloneTests = @(
+    "test-05-ghost-demo",
+    "test-09-no-activate-modes"
+)
 if ($TestName -in $standaloneTests) {
     Write-Host "Standalone test: $TestName (manages its own ghostty process)"
     $testFile = Join-Path $PSScriptRoot "$TestName.ps1"

--- a/tests/winui3/test-09-no-activate-modes.ps1
+++ b/tests/winui3/test-09-no-activate-modes.ps1
@@ -1,0 +1,208 @@
+param([switch]$IncludeDefault)
+
+# test-09-no-activate-modes.ps1
+# Verify the three KS_NO_ACTIVATE modes set up by App.zig step 5:
+#
+#   unset    → SW_SHOWNORMAL + SetForegroundWindow (focus moves to ghostty)
+#   hide     → SW_HIDE                              (window invisible)
+#   visible  → SW_SHOWNOACTIVATE                    (visible, no activation)
+#
+# Strategy: log-marker assertion. Each mode emits a distinct
+# `initXaml step 5: ShowWindow(...)` line. We:
+#
+#   1. record the current ghostty_debug.log size
+#   2. launch ghostty with the env var set, capture exact PID via
+#      Start-Process -PassThru
+#   3. wait for the log to grow to include "startup stage:
+#      window_activated" (proves step 5 ran)
+#   4. terminate ghostty by PID only (NEVER by image / title — would
+#      kill the developer's other ghostty sessions)
+#   5. read the new log slice and assert it contains the expected
+#      `ShowWindow(...)` marker for the mode under test
+#
+# Why log-marker rather than GetForegroundWindow comparison: the
+# WinUI3 / XAML Islands runtime can call its own activation paths
+# after our step 5 returns. Asserting on actual foreground state
+# would couple this test to internal WinUI3 behaviour that's outside
+# the scope of `KS_NO_ACTIVATE`. The log marker proves OUR dispatch
+# logic chose the right SW_ flag — which is what the env var
+# contract guarantees. Anything else (XAML stealing focus despite
+# SHOWNOACTIVATE) is a separate, follow-up concern.
+#
+# Companion to the Zig unit tests in `App.zig` covering env-value →
+# enum dispatch (`parseNoActivateMode`). Together they certify
+# (1) "right enum value chosen for given env value" and
+# (2) "right ShowWindow flag fired for given enum value".
+
+$ErrorActionPreference = 'Stop'
+$testName = "test-09-no-activate-modes"
+
+Import-Module "$PSScriptRoot\test-helpers.psm1" -Force
+
+$exePath = Join-Path $PSScriptRoot "..\..\zig-out-winui3\bin\ghostty.exe"
+$exePath = (Resolve-Path $exePath -ErrorAction Stop).Path
+if (-not (Test-Path $exePath)) {
+    throw "$testName FAIL: ghostty.exe not found at $exePath"
+}
+
+$logPath = Join-Path $env:TEMP "ghostty_debug.log"
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+function Read-Log-File {
+    # Read an entire log file (per-test stderr redirect). Tolerant
+    # of read failures while ghostty has the file open — retries
+    # with FILE_SHARE_READ. Returns "" on any IO error.
+    param([string]$Path, [int]$RetryCount = 3)
+    if (-not (Test-Path $Path)) { return "" }
+    for ($attempt = 1; $attempt -le $RetryCount; $attempt++) {
+        try {
+            $fs = [System.IO.FileStream]::new(
+                $Path,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete
+            )
+            try {
+                $reader = [System.IO.StreamReader]::new($fs, [System.Text.Encoding]::UTF8, $false, 4096, $true)
+                try {
+                    return $reader.ReadToEnd()
+                } finally {
+                    $reader.Dispose()
+                }
+            } finally {
+                $fs.Dispose()
+            }
+        } catch {
+            if ($attempt -lt $RetryCount) { Start-Sleep -Milliseconds 200 }
+        }
+    }
+    return ""
+}
+
+function Get-StepFiveLine {
+    param([string]$LogContent)
+    if (-not $LogContent) { return $null }
+    $m = [regex]::Match($LogContent, "initXaml step 5: ShowWindow[^\r\n]*")
+    if (-not $m.Success) { return $null }
+    return $m.Value
+}
+
+function Wait-For-StepFiveInFile {
+    # Poll a per-test log file until a step-5 line appears.
+    # Because the file is unique to this test process, the line we
+    # find is unambiguously from the launch we just did — no
+    # baseline counting, no other-ghostty interference.
+    param([string]$Path, [int]$TimeoutMs = 15000)
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMs)
+    while ((Get-Date) -lt $deadline) {
+        $log = Read-Log-File -Path $Path
+        $line = Get-StepFiveLine -LogContent $log
+        if ($line) { return $line }
+        Start-Sleep -Milliseconds 200
+    }
+    return $null
+}
+
+function Run-One-Mode {
+    param(
+        [string]$Mode,                 # "" | "hide" | "visible"
+        [string]$ExpectedMarker        # substring expected in the step-5 line
+    )
+    # Compose env. Restore on every exit path.
+    $prev = $env:KS_NO_ACTIVATE
+    if ($Mode -eq "") {
+        $env:KS_NO_ACTIVATE = $null
+    } else {
+        $env:KS_NO_ACTIVATE = $Mode
+    }
+    $env:GHOSTTY_CONTROL_PLANE = $null
+    $env:WINDOWS_TERMINAL_CONTROL_PLANE = $null
+
+    $modeLabel = if ($Mode -eq "") { "default" } else { $Mode }
+
+    # Per-test stderr redirect file. ghostty's `attachDebugConsole`
+    # also ATTEMPTS to redirect stderr to %TEMP%\ghostty_debug.log
+    # via SetStdHandle, but that only succeeds if it can open the
+    # file (FILE_SHARE_READ only). When PowerShell pre-binds the
+    # process's stderr via Start-Process -RedirectStandardError,
+    # the SetStdHandle inside ghostty may or may not stick — but
+    # the early debug logs (including step 5) are reliably captured
+    # in our redirect target either way because they fire BEFORE
+    # attachDebugConsole's potential overwrite.
+    $stderrPath = Join-Path $env:TEMP ("ghostty_test09_${modeLabel}_$([System.Diagnostics.Process]::GetCurrentProcess().Id).log")
+    if (Test-Path $stderrPath) { Remove-Item $stderrPath -Force }
+
+    $proc = $null
+    try {
+        $proc = Start-Process -FilePath $exePath `
+                              -PassThru `
+                              -WindowStyle Normal `
+                              -RedirectStandardError $stderrPath
+        Write-Host "  [$modeLabel] PID=$($proc.Id), stderr→$stderrPath, waiting for step 5 line ..." -ForegroundColor DarkGray
+
+        $line = Wait-For-StepFiveInFile -Path $stderrPath -TimeoutMs 15000
+        if (-not $line) {
+            # Fall back to the shared ghostty_debug.log — on this
+            # codepath ghostty's own attachDebugConsole may have
+            # taken over stderr.
+            $line = Wait-For-StepFiveInFile -Path $logPath -TimeoutMs 3000
+        }
+        if (-not $line) {
+            throw "[$Mode] FAIL: no 'initXaml step 5: ShowWindow' line in $stderrPath OR $logPath within 18 s — process may have crashed pre-step-5"
+        }
+        if ($line -notmatch [regex]::Escape($ExpectedMarker)) {
+            throw "[$Mode] FAIL: step-5 line did not contain '$ExpectedMarker'. Got: $line"
+        }
+        Write-Host "  [$modeLabel] OK — '$line'" -ForegroundColor Green
+    } finally {
+        $env:KS_NO_ACTIVATE = $prev
+        if ($proc -and -not $proc.HasExited) {
+            # Stop ONLY this PID. Never image-name kill, never title kill —
+            # the dev box has many ghostty sessions running and a
+            # broad-stroke kill would clobber the user's actual work.
+            try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+        }
+        # Brief settle so the next Run-One-Mode's launch overwrites
+        # this process's log section cleanly.
+        Start-Sleep -Milliseconds 800
+    }
+}
+
+# ----------------------------------------------------------------------
+# Subtest 1: KS_NO_ACTIVATE=visible
+# ----------------------------------------------------------------------
+Run-One-Mode -Mode "visible" `
+             -ExpectedMarker "ShowWindow(SHOWNOACTIVATE)"
+
+# ----------------------------------------------------------------------
+# Subtest 2: KS_NO_ACTIVATE=hide
+# ----------------------------------------------------------------------
+Run-One-Mode -Mode "hide" `
+             -ExpectedMarker "ShowWindow(HIDE)"
+
+# ----------------------------------------------------------------------
+# Subtest 3: alias coverage — KS_NO_ACTIVATE=show resolves to visible
+# ----------------------------------------------------------------------
+# Cheaper to run because the parser is identical to the `=visible` case;
+# this is the integration-level pin for the alias that the parser-side
+# Zig unit test already covers symbolically.
+Run-One-Mode -Mode "show" `
+             -ExpectedMarker "ShowWindow(SHOWNOACTIVATE)"
+
+# ----------------------------------------------------------------------
+# Subtest 4: KS_NO_ACTIVATE unset — default behaviour
+# ----------------------------------------------------------------------
+# Default mode actually steals foreground (that IS the spec). Skip on
+# a developer's interactive box because it's disruptive even though
+# it's correct. Run with -IncludeDefault on CI / clean boxes.
+if ($IncludeDefault) {
+    Run-One-Mode -Mode "" `
+                 -ExpectedMarker "ShowWindow + SetForegroundWindow OK"
+} else {
+    Write-Host "  [default] SKIP — pass -IncludeDefault to exercise the focus-stealing default path" -ForegroundColor Yellow
+}
+
+Write-Host "$testName PASS" -ForegroundColor Green


### PR DESCRIPTION
> この記事はAIによって起草されました。

Closes #247.

Adds a third launch-time activation mode for non-interactive callers that want a visible ghostty window without disrupting the operator's foreground state.

## Why

Background batch launchers — deckpilot e2e tests, scripted spawn-many, session-restore-on-boot — repeatedly create ghostty windows in quick succession. Default behaviour (\`SW_SHOWNORMAL\` + \`SetForegroundWindow\`) steals focus on every spawn; the existing \`KS_NO_ACTIVATE=1\` mode (\`SW_HIDE\`) hides the window entirely, which is wrong for use cases where the operator wants to *see* the new sessions, just not have their typing redirected mid-stream.

## What

\`KS_NO_ACTIVATE\` env var now takes three modes (case-insensitive):

| Value                           | ShowWindow flag       | Effect                                                              |
|---------------------------------|-----------------------|---------------------------------------------------------------------|
| unset / \`0\` / \`false\`       | \`SW_SHOWNORMAL\` + \`SetForegroundWindow\` | unchanged interactive launch (focus moves to ghostty) |
| \`1\` / \`true\` / \`hide\`     | \`SW_HIDE\`           | UIA-test path, window invisible (existing)                          |
| \`visible\` / \`show\` / \`background\` | \`SW_SHOWNOACTIVATE\` | window visible at normal size, foreground unchanged (new)     |

The dispatch logic is extracted into a pure function \`parseNoActivateMode([]const u8) NoActivateMode\` so unit tests cover the alias matrix without booting WinUI3.

## Tests

### Unit (Zig, in-source — \`src/apprt/winui3/App.zig\`)

```
parseNoActivateMode: hide aliases                       — 1 / true / TRUE / hide / Hide / HIDE
parseNoActivateMode: visible aliases                    — visible / show / background (case variants)
parseNoActivateMode: unknown values fall back to default — empty / 0 / false / typo / 01 / hidden
parseNoActivateMode: hide and visible never overlap      — show1 / 1show / hide1 don't accidentally match
```

### E2E (PowerShell — \`tests/winui3/test-09-no-activate-modes.ps1\`)

```
[visible] OK — 'initXaml step 5: ShowWindow(SHOWNOACTIVATE) — KS_NO_ACTIVATE=visible'
[hide]    OK — 'initXaml step 5: ShowWindow(HIDE) — KS_NO_ACTIVATE=hide'
[show]    OK — 'initXaml step 5: ShowWindow(SHOWNOACTIVATE) — KS_NO_ACTIVATE=visible'
[default] SKIP — pass -IncludeDefault to exercise the focus-stealing default path
test-09-no-activate-modes PASS
```

Run via:

```
pwsh -NoProfile -File tests/winui3/run-single-test.ps1 -TestName test-09-no-activate-modes
```

The E2E uses per-test stderr redirect (\`Start-Process -RedirectStandardError\`) so multiple ghostty processes on a dev box don't race on the shared \`ghostty_debug.log\`. Cleanup uses \`Stop-Process -Id\` on the captured PID **only** — never image-name kill, never title kill — so the operator's other ghostty sessions are untouched.

## Files

| Type | Path | Δlines | Purpose |
|------|------|------:|---------|
| mod  | \`src/apprt/winui3/os.zig\`                    |  +13 | \`SW_SHOWNOACTIVATE\` + \`SW_SHOWNA\` constants |
| mod  | \`src/apprt/winui3/App.zig\`                   | +132 | \`NoActivateMode\` enum, \`parseNoActivateMode\`, \`readNoActivateMode\`, 3-arm dispatch in step 5, 4 unit tests |
| add  | \`tests/winui3/test-09-no-activate-modes.ps1\` | +208 | 3-mode E2E (visible / hide / show alias) |
| mod  | \`tests/winui3/run-single-test.ps1\`           |   +4 | register test-09 as standalone (manages its own ghostty) |

4 files, +357 / -2.

## Caller wiring (separate PR)

[YuujiKamura/deckpilot](https://github.com/YuujiKamura/deckpilot) gains a \`deckpilot launch ... --background\` flag that exports \`KS_NO_ACTIVATE=visible\` so deckpilot's e2e suite stops stealing focus from the developer during background spawn-many. That PR depends on this one.

## Out of scope

- A CLI flag (\`--no-activate=visible\`) on top of the env var. The env var is enough for current callers; if a CLI flag becomes necessary later it can be a thin alias around the same \`parseNoActivateMode\`.
- WinUI3-internal activation paths that may re-take foreground after step 5. The env var contract is "OUR step-5 dispatch chooses the right \`SW_\` flag"; if XAML Islands later activates on its own, that's a separate fix and a separate test.
- Headless mode (no window at all). Different feature, different request.

## Notes for review

- \`uia-smoke\` lefthook fails on this dev box because of pre-existing CP / deckpilot session-detection test failures (\`No CP session available\`). Those tests are unrelated to this change — they need a deckpilot daemon registered ahead of the run. Pushed with \`LEFTHOOK_EXCLUDE=uia-smoke\` (the documented per-hook opt-out), not \`--no-verify\`.
- \`render_song::piece_*()\`-equivalent files: there's nothing comparable in ghostty to preserve in the \`KS_NO_ACTIVATE=hide\` direction. The existing \`SW_HIDE\` behaviour is preserved byte-for-byte (same flag, same code path, just routed through the new enum).

🤖 Filed via Claude Code